### PR TITLE
Replace "jack-mock" with "mock"

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,7 +1,7 @@
 #lang info
 (define collection "json-rpc-client")
 (define deps '("base"))
-(define build-deps '("scribble-lib" "racket-doc" "rackunit-lib" "jack-mock"))
+(define build-deps '("scribble-lib" "racket-doc" "rackunit-lib" "mock"))
 (define scribblings '(("scribblings/json-rpc-client.scrbl" ())))
 (define pkg-desc "Library for talking with json-rpc APIs")
 (define version "0.1")


### PR DESCRIPTION
Looks like this dependency has changed name in the repositories?